### PR TITLE
Create VectorizedOptimizer.hpp

### DIFF
--- a/galois/optimization/VectorizedOptimizer.hpp
+++ b/galois/optimization/VectorizedOptimizer.hpp
@@ -1,0 +1,262 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <tuple>
+
+#include "cpuinfo.h"
+#include "galois/helper.hpp"
+#include "galois/ir/builder.hpp"
+#include "galois/ir/ir.hpp"
+#include "galois/op/arithmetic.hpp"
+#include "galois/ir/view.hpp"
+#include "galois/transform/each.hpp"
+
+namespace galois::optimization {
+
+// 简单的 CPU SIMD 信息结构，只记录 SIMD 位宽，方便后续判断能否矢量化。
+class VectorizedCpuInfo {
+   public:
+    static std::shared_ptr<VectorizedCpuInfo> Create() {
+        auto self = std::shared_ptr<VectorizedCpuInfo>(new VectorizedCpuInfo);
+        cpuinfo_initialize();
+        self->DetectCpuFeatures();
+        return self;
+    }
+
+    int64_t SimdBits() const { return simd_bits; }
+
+   private:
+    VectorizedCpuInfo() = default;
+
+    void DetectCpuFeatures() {
+        simd_bits = 0;
+        if (cpuinfo_has_x86_avx512f()) {
+            simd_bits = 512;
+            return;
+        }
+        if (cpuinfo_has_x86_avx2() || cpuinfo_has_x86_avx()) {
+            simd_bits = 256;
+            return;
+        }
+        if (cpuinfo_has_x86_sse() || cpuinfo_has_x86_sse2() || cpuinfo_has_arm_neon()) {
+            simd_bits = 128;
+            return;
+        }
+    }
+
+    int64_t simd_bits = 0;
+};
+
+// VectorizedOptimizer：针对二元算子（加减乘除）做尾维整除时的 SIMD 化。
+class VectorizedOptimizer {
+   protected:
+    VectorizedOptimizer() = default;
+
+   private:
+    struct VectorizationConfig {
+        ir::ArithmeticInstruction::Operation operation;   // 算子类型：Add/Sub/Mul/Div
+        std::shared_ptr<ir::TensorType> output_type;       // 原输出的标量类型
+        std::shared_ptr<ir::TensorType> vector_chunk_type; // `<lanes x T>` × chunk_shape
+        int64_t lanes = 0;                                 // SIMD 宽度（元素个数）
+    };
+
+
+   public:
+    static std::shared_ptr<VectorizedOptimizer> Create() {
+        std::shared_ptr<VectorizedOptimizer> self(new VectorizedOptimizer);
+        self->cpu_info = VectorizedCpuInfo::Create();
+        return self;
+    }
+
+    // 若满足矢量化条件，则构造新的 `_vec` 算子并返回；否则直接返回原算子。
+    std::shared_ptr<ir::Operator> Optimize(std::shared_ptr<ir::Operator> ir_operator) {
+        if (!ir_operator) return ir_operator;
+
+        auto config = this->BuildVectorizationConfig(ir_operator);
+        if (!config) {
+            return ir_operator;
+        }
+
+        auto ir_builder = ir::Builder::Create();
+        ir_builder->id = reinterpret_cast<uintptr_t>(ir_builder.get());
+        auto [ir_vectorized_operator, scope] = ir_builder->CreateOperator(
+            ir_operator->GetOperatorType(), ir_operator->name + "_vec");
+
+        auto ir_lhs = ir_vectorized_operator->inputs[0];
+        auto ir_rhs = ir_vectorized_operator->inputs[1];
+
+        auto ir_output = this->EmitVectorizedComputation(ir_builder, ir_lhs, ir_rhs, *config);
+        if (!ir_output) {
+            return ir_operator;
+        }
+
+        ir_builder->Return(ir_output);
+        scope.reset();
+        return ir_vectorized_operator;
+    }
+
+   private:
+    // 检测算子可否矢量化，并构造向量块类型；若不满足条件返回 nullopt。
+    std::optional<VectorizationConfig> BuildVectorizationConfig(
+        std::shared_ptr<ir::Operator> ir_operator) {
+        if (!ir_operator || ir_operator->inputs.size() != 2) {
+            return std::nullopt;
+        }
+
+        auto maybe_operation = this->DetectArithmeticOperation(ir_operator);
+        if (!maybe_operation) {
+            return std::nullopt;
+        }
+
+        auto ir_operator_type = ir_operator->GetOperatorType();
+        if (!ir_operator_type) {
+            return std::nullopt;
+        }
+
+        auto ir_output_type = ir_operator_type->output_type;
+        if (!ir_output_type) {
+            return std::nullopt;
+        }
+
+        if (ir_output_type->DenseType() != ir_output_type) {
+            return std::nullopt;
+        }
+
+        auto ir_element_type = ir_output_type->DataType();
+        auto ir_real_number_type = Cast<ir::RealNumberType>(ir_element_type);
+        if (!ir_real_number_type) {
+            return std::nullopt;
+        }
+
+        if (!this->cpu_info) {
+            return std::nullopt;
+        }
+
+        auto simd_bits = this->cpu_info->SimdBits();
+        if (simd_bits <= 0) {
+            return std::nullopt;
+        }
+
+        auto element_bits = ir_real_number_type->bits;
+        if (element_bits <= 0) {
+            return std::nullopt;
+        }
+
+        if (simd_bits % element_bits != 0) {
+            return std::nullopt;
+        }
+
+        auto lanes = simd_bits / element_bits;
+        if (lanes <= 1) {
+            return std::nullopt;
+        }
+
+        if (!IsPowerOfTwo(lanes)) {
+            return std::nullopt;
+        }
+
+        if (ir_output_type->NormalizeSize() <= 0) {
+            return std::nullopt;
+        }
+
+        auto normalized_shape = ir_output_type->NormalizeShape();
+        if (!normalized_shape.size()) {
+            return std::nullopt;
+        }
+
+        VectorizationConfig config;
+        config.operation = *maybe_operation;
+        config.output_type = ir_output_type;
+        // 仅在最后一维可以被 SIMD 宽度整除时启用矢量化。
+        auto vector_type = ir_element_type->Tile(lanes);
+        auto last_dim_index = static_cast<int>(normalized_shape.size()) - 1;
+        int64_t last_dim = normalized_shape[last_dim_index];
+        if (last_dim % lanes != 0) {
+            return std::nullopt;
+        }
+
+        Eigen::VectorXi64 chunk_shape = normalized_shape;
+        chunk_shape[last_dim_index] = last_dim / lanes;
+
+        // `<lanes x T>` × chunk_shape 的 tensor，即整体按向量块分块后的类型。
+        config.vector_chunk_type = vector_type->Tile(chunk_shape);
+        config.lanes = lanes;
+        return config;
+    }
+
+    // 检查算子内部的算术指令是否一致（只支持纯加/减/乘/除）。
+    std::optional<ir::ArithmeticInstruction::Operation> DetectArithmeticOperation(
+        std::shared_ptr<ir::Operator> ir_operator) {
+        std::optional<ir::ArithmeticInstruction::Operation> maybe_operation;
+        bool mismatch = false;
+        transform::Each<ir::ArithmeticInstruction>(
+            ir_operator, [&](std::shared_ptr<ir::ArithmeticInstruction> instruction) {
+                if (!maybe_operation) {
+                    maybe_operation = instruction->operation;
+                    return;
+                }
+                if (*maybe_operation != instruction->operation) {
+                    mismatch = true;
+                }
+            });
+        if (!maybe_operation || mismatch) {
+            return std::nullopt;
+        }
+        return maybe_operation;
+    }
+
+    // 将输入/输出一次性 BitCast 成向量块，并复用原算子完成运算。
+    std::shared_ptr<ir::Tensor> EmitVectorizedComputation(
+        std::shared_ptr<ir::Builder> ir_builder, std::shared_ptr<ir::Tensor> ir_lhs,
+        std::shared_ptr<ir::Tensor> ir_rhs, const VectorizationConfig& config) {
+
+        // 先 Alloca 一个输出张量并构造向量块视图，后续在自管的 Grid 中写回。
+        auto ir_output = ir_builder->Alloca(config.output_type);
+
+        // 将原始张量视为 `<lanes x T>` 的块数组，方便后端发 SIMD 指令。
+        auto ir_lhs_vec = ir_builder->BitCastView(ir_lhs, config.vector_chunk_type);
+        auto ir_rhs_vec = ir_builder->BitCastView(ir_rhs, config.vector_chunk_type);
+        auto ir_out_vec = ir_builder->BitCastView(ir_output, config.vector_chunk_type);
+
+        auto [ir_grid, scope_guard] = ir_builder->CreateGrid(config.vector_chunk_type->shape);
+
+        auto ir_accessor_lhs = ir_builder->CreateIdentityAccessor(ir_lhs_vec);
+        auto ir_accessor_rhs = ir_builder->CreateIdentityAccessor(ir_rhs_vec);
+        auto ir_accessor_out = ir_builder->CreateIdentityAccessor(ir_out_vec);
+
+        auto ir_vec_result =
+            this->ApplyArithmeticOperation(ir_builder, ir_accessor_lhs, ir_accessor_rhs,
+                                           config.operation);
+        if (!ir_vec_result) {
+            return nullptr;
+        }
+
+        ir_builder->Write(ir_vec_result, ir_accessor_out);
+        return ir_output;
+    }
+
+    std::shared_ptr<VectorizedCpuInfo> cpu_info = nullptr;  // 缓存 CPU SIMD 信息
+
+    // 直接发射底层算术指令，实现加减乘除。
+    std::shared_ptr<ir::Tensor> ApplyArithmeticOperation(
+        std::shared_ptr<ir::Builder> ir_builder, std::shared_ptr<ir::Tensor> lhs,
+        std::shared_ptr<ir::Tensor> rhs, ir::ArithmeticInstruction::Operation operation) {
+        switch (operation) {
+            case ir::ArithmeticInstruction::Operation::Add:
+                return ir_builder->Add(lhs, rhs);
+            case ir::ArithmeticInstruction::Operation::Sub:
+                return ir_builder->Sub(lhs, rhs);
+            case ir::ArithmeticInstruction::Operation::Mul:
+                return ir_builder->Mul(lhs, rhs);
+            case ir::ArithmeticInstruction::Operation::Div:
+                return ir_builder->Div(lhs, rhs);
+            default:
+                return nullptr;
+        }
+    }
+
+};
+
+}  // namespace galois::optimization

--- a/galois/optimization/VectorizedOptimizer_fill.hpp
+++ b/galois/optimization/VectorizedOptimizer_fill.hpp
@@ -1,0 +1,188 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <tuple>
+
+#include "cpuinfo.h"
+#include "galois/helper.hpp"
+#include "galois/ir/builder.hpp"
+#include "galois/ir/ir.hpp"
+#include "galois/ir/view.hpp"
+#include "galois/optimization/VectorizedOptimizer.hpp"
+#include "galois/op/fill.hpp"
+#include "galois/transform/each.hpp"
+
+namespace galois::optimization {
+
+// VectorizedOptimizerFill：在矢量化运算前对输出张量执行 Fill，保证初始值为 0。
+// 设计目的：保留 VectorizedOptimizer 的 SIMD 优化能力，同时补全“先清零再计算”的语义，
+// 以兼容需要依赖初始值的算子场景。例如某些操作期望输出张量在写入前已经被初始化，
+// 这里统一用 FillCreator 写入 0，避免残留随机值影响结果。
+class VectorizedOptimizerFill {
+   protected:
+    VectorizedOptimizerFill() = default;
+
+   private:
+    struct VectorizationConfig {
+        ir::ArithmeticInstruction::Operation operation;
+        std::shared_ptr<ir::TensorType> output_type;
+        std::shared_ptr<ir::TensorType> vector_chunk_type;
+        int64_t lanes = 0;
+    };
+
+   public:
+    static std::shared_ptr<VectorizedOptimizerFill> Create() {
+        auto self = std::shared_ptr<VectorizedOptimizerFill>(new VectorizedOptimizerFill);
+        self->cpu_info = VectorizedCpuInfo::Create();
+        return self;
+    }
+
+    std::shared_ptr<ir::Operator> Optimize(std::shared_ptr<ir::Operator> ir_operator) {
+        if (!ir_operator) return ir_operator;
+
+        // 构造矢量化配置（lane 数、向量块类型等），若失败则退化为原算子。
+        auto config = this->BuildVectorizationConfig(ir_operator);
+        if (!config) return ir_operator;
+
+        auto ir_builder = ir::Builder::Create();
+        ir_builder->id = reinterpret_cast<uintptr_t>(ir_builder.get());
+        auto [ir_vectorized_operator, scope] = ir_builder->CreateOperator(
+            ir_operator->GetOperatorType(), ir_operator->name + "_vec_fill");
+
+        auto ir_lhs = ir_vectorized_operator->inputs[0];
+        auto ir_rhs = ir_vectorized_operator->inputs[1];
+
+        // 发射填零 + SIMD 主体，若失败同样退化。
+        auto ir_output = this->EmitVectorizedComputation(ir_builder, ir_lhs, ir_rhs, *config);
+        if (!ir_output) return ir_operator;
+
+        ir_builder->Return(ir_output);
+        scope.reset();
+        return ir_vectorized_operator;
+    }
+
+   private:
+    std::optional<VectorizationConfig> BuildVectorizationConfig(
+        std::shared_ptr<ir::Operator> ir_operator) {
+        if (!ir_operator || ir_operator->inputs.size() != 2) return std::nullopt;
+
+        auto maybe_operation = this->DetectArithmeticOperation(ir_operator);
+        if (!maybe_operation) return std::nullopt;
+
+        auto ir_operator_type = ir_operator->GetOperatorType();
+        if (!ir_operator_type) return std::nullopt;
+
+        auto ir_output_type = ir_operator_type->output_type;
+        if (!ir_output_type) return std::nullopt;
+
+        if (ir_output_type->DenseType() != ir_output_type) return std::nullopt;
+
+        auto ir_element_type = ir_output_type->DataType();
+        auto ir_real_number_type = Cast<ir::RealNumberType>(ir_element_type);
+        if (!ir_real_number_type) return std::nullopt;
+
+        if (!this->cpu_info) return std::nullopt;
+
+        auto simd_bits = this->cpu_info->SimdBits();
+        if (simd_bits <= 0) return std::nullopt;
+
+        auto element_bits = ir_real_number_type->bits;
+        if (element_bits <= 0) return std::nullopt;
+
+        if (simd_bits % element_bits != 0) return std::nullopt;
+
+        auto lanes = simd_bits / element_bits;
+        if (lanes <= 1) return std::nullopt;
+        if (!IsPowerOfTwo(lanes)) return std::nullopt;
+        if (ir_output_type->NormalizeSize() <= 0) return std::nullopt;
+
+        auto normalized_shape = ir_output_type->NormalizeShape();
+        if (!normalized_shape.size()) return std::nullopt;
+
+        VectorizationConfig config;
+        config.operation = *maybe_operation;
+        config.output_type = ir_output_type;
+
+        auto vector_type = ir_element_type->Tile(lanes);
+        auto last_dim_index = static_cast<int>(normalized_shape.size()) - 1;
+        int64_t last_dim = normalized_shape[last_dim_index];
+        if (last_dim % lanes != 0) return std::nullopt;
+
+        Eigen::VectorXi64 chunk_shape = normalized_shape;
+        chunk_shape[last_dim_index] = last_dim / lanes;
+
+        config.vector_chunk_type = vector_type->Tile(chunk_shape);
+        config.lanes = lanes;
+        return config;
+    }
+
+    std::optional<ir::ArithmeticInstruction::Operation> DetectArithmeticOperation(
+        std::shared_ptr<ir::Operator> ir_operator) {
+        std::optional<ir::ArithmeticInstruction::Operation> maybe_operation;
+        bool mismatch = false;
+        transform::Each<ir::ArithmeticInstruction>(
+            ir_operator, [&](std::shared_ptr<ir::ArithmeticInstruction> instruction) {
+                if (!maybe_operation) {
+                    maybe_operation = instruction->operation;
+                    return;
+                }
+                if (*maybe_operation != instruction->operation) mismatch = true;
+            });
+        if (!maybe_operation || mismatch) return std::nullopt;
+        return maybe_operation;
+    }
+
+    std::shared_ptr<ir::Tensor> EmitVectorizedComputation(
+        std::shared_ptr<ir::Builder> ir_builder, std::shared_ptr<ir::Tensor> ir_lhs,
+        std::shared_ptr<ir::Tensor> ir_rhs, const VectorizationConfig& config) {
+        auto ir_output = ir_builder->Alloca(config.output_type);
+
+        // 先显式 Fill，保证输出张量处于已知状态（与 BinaryCreator 行为保持一致）。
+        auto ir_zero = ir_builder->GetZero(config.output_type->DataType());
+        ir_builder->ExpressCreator<op::FillCreator>({ir_output, ir_zero});
+
+        // 将张量视图转换为 `<lanes x T>` × chunk_shape`，为后续 SIMD 运算做准备。
+        auto ir_lhs_vec = ir_builder->BitCastView(ir_lhs, config.vector_chunk_type);
+        auto ir_rhs_vec = ir_builder->BitCastView(ir_rhs, config.vector_chunk_type);
+        auto ir_out_vec = ir_builder->BitCastView(ir_output, config.vector_chunk_type);
+
+        auto [ir_grid, scope_guard] = ir_builder->CreateGrid(config.vector_chunk_type->shape);
+
+        auto ir_accessor_lhs = ir_builder->CreateIdentityAccessor(ir_lhs_vec);
+        auto ir_accessor_rhs = ir_builder->CreateIdentityAccessor(ir_rhs_vec);
+        auto ir_accessor_out = ir_builder->CreateIdentityAccessor(ir_out_vec);
+
+        auto ir_vec_result =
+            this->ApplyArithmeticOperation(ir_builder, ir_accessor_lhs, ir_accessor_rhs,
+                                           config.operation);
+        if (!ir_vec_result) return nullptr;
+
+        ir_builder->Write(ir_vec_result, ir_accessor_out);
+        return ir_output;
+    }
+
+    std::shared_ptr<ir::Tensor> ApplyArithmeticOperation(
+        std::shared_ptr<ir::Builder> ir_builder, std::shared_ptr<ir::Tensor> lhs,
+        std::shared_ptr<ir::Tensor> rhs, ir::ArithmeticInstruction::Operation operation) {
+        // 直接复用 Builder 的底层算术指令，确保真正生成 SIMD 二元操作。
+        switch (operation) {
+            case ir::ArithmeticInstruction::Operation::Add:
+                return ir_builder->Add(lhs, rhs);
+            case ir::ArithmeticInstruction::Operation::Sub:
+                return ir_builder->Sub(lhs, rhs);
+            case ir::ArithmeticInstruction::Operation::Mul:
+                return ir_builder->Mul(lhs, rhs);
+            case ir::ArithmeticInstruction::Operation::Div:
+                return ir_builder->Div(lhs, rhs);
+            default:
+                return nullptr;
+        }
+    }
+
+    // CPU SIMD 能力缓存，与基础 VectorizedOptimizer 共用探测逻辑。
+    std::shared_ptr<VectorizedCpuInfo> cpu_info = nullptr;
+};
+
+}  // namespace galois::optimization

--- a/tests/vectorized_test.cpp
+++ b/tests/vectorized_test.cpp
@@ -1,0 +1,160 @@
+#include <cmath>
+#include <cstdlib>
+#include <memory>
+
+#include "galois/op/fill.hpp"
+#include "galois/optimization/VectorizedOptimizer.hpp"
+#include "galois/optimization/VectorizedOptimizer_fill.hpp"
+#include "tests/galois_test.hpp"
+
+namespace {
+
+// 将 std::vector 形式的形状转换成 Eigen 向量，方便构造张量类型。
+Eigen::VectorXi64 MakeShape(const std::vector<int64_t> &shape_vec) {
+    Eigen::VectorXi64 shape(shape_vec.size());
+    for (size_t i = 0; i < shape_vec.size(); ++i) {
+        shape(static_cast<int>(i)) = shape_vec[i];
+    }
+    return shape;
+}
+
+// 把形状编码成 `[d0xd1x...]` 的字符串，便于输出结果。
+std::string ShapeToString(const std::vector<int64_t> &shape_vec) {
+    std::ostringstream oss;
+    oss << '[';
+    for (size_t i = 0; i < shape_vec.size(); ++i) {
+        if (i) oss << 'x';
+        oss << shape_vec[i];
+    }
+    oss << ']';
+    return oss.str();
+}
+
+using Buffer = std::unique_ptr<float, decltype(&std::free)>;
+
+// 申请对齐内存，确保与 JIT 输出的对齐策略一致。
+Buffer AllocateAligned(int64_t elements) {
+    return Buffer(static_cast<float *>(galois::auto_aligned_alloc(elements * sizeof(float))),
+                  &std::free);
+}
+
+// 为输入缓冲区填充可重复的浮点序列，避免使用随机数增加噪音。
+void FillBuffer(float *ptr, int64_t elements, float scale) {
+    for (int64_t i = 0; i < elements; ++i) {
+        ptr[i] = static_cast<float>((i % 257) * scale);
+    }
+}
+
+enum class AddMode { Scalar, Vectorized, VectorizedFill };
+
+// 根据模式构造不同的加法算子：纯标量或矢量化优化版本。
+std::shared_ptr<ir::Operator> BuildAddOperator(const Eigen::VectorXi64 &shape, AddMode mode) {
+    auto input_type = ir::f32->Tile(shape);
+    auto builder = ir::Builder::Create();
+    auto base = builder->CreateOperatorByCreator<op::AddCreator>({input_type, input_type});
+
+    switch (mode) {
+        case AddMode::Scalar:
+            return base;
+        case AddMode::Vectorized: {
+            auto optimizer = optimization::VectorizedOptimizer::Create();
+            return optimizer->Optimize(base);
+        }
+        case AddMode::VectorizedFill: {
+            auto optimizer = optimization::VectorizedOptimizerFill::Create();
+            return optimizer->Optimize(base);
+        }
+    }
+    return base;
+}
+
+// 运行单次加法算子测试，打印耗时与带宽，方便比较不同模式。
+void RunAddTest(const std::vector<int64_t> &shape_vec, AddMode mode) {
+    auto shape = MakeShape(shape_vec);
+    int64_t elements = 1;
+    for (auto dim : shape_vec) {
+        elements *= dim;
+    }
+
+    auto op = BuildAddOperator(shape, mode);
+    auto jit_engine = jit::Engine::Create();
+    auto add_fun =
+        jit_engine->EmitOperatorSymbol<float *(*)(float *, float *)>(op);
+
+    auto lhs = AllocateAligned(elements);
+    auto rhs = AllocateAligned(elements);
+
+    FillBuffer(lhs.get(), elements, 0.25f);
+    FillBuffer(rhs.get(), elements, 1.5f);
+
+    auto bytes = static_cast<double>(elements) * 2 * sizeof(float);
+
+    auto t0 = std::chrono::steady_clock::now();
+    auto result = add_fun(lhs.get(), rhs.get());
+    auto t1 = std::chrono::steady_clock::now();
+
+    auto elapsed = std::chrono::duration_cast<std::chrono::duration<double>>(t1 - t0);
+    const char* mode_suffix = "";
+    switch (mode) {
+        case AddMode::Scalar:
+            mode_suffix = "(scalar)";
+            break;
+        case AddMode::Vectorized:
+            mode_suffix = "(vec)";
+            break;
+        case AddMode::VectorizedFill:
+            mode_suffix = "(vec_fill)";
+            break;
+    }
+    fmt::print("Add{} {}: {:.3f} ms, {:.3f} GB/s\n", mode_suffix, ShapeToString(shape_vec),
+               elapsed.count() * 1e3, bytes / elapsed.count() / 1e9);
+
+    std::free(result);
+}
+
+}  // namespace
+
+TEST(GaloisTests, TestAddScalar) {
+    // 标量模式，作为矢量化优化的基线。
+    std::vector<std::vector<int64_t>> shapes = {
+        {1024000000},
+        {8192, 8192},
+        {2048, 1024},
+        {512, 512, 256},
+        {128, 128, 64, 16},
+    };
+
+    for (const auto &shape : shapes) {
+        RunAddTest(shape, AddMode::Scalar);
+    }
+}
+
+TEST(GaloisTests, TestAddVectorized) {
+    // 直接使用 VectorizedOptimizer，比对性能提升。
+    std::vector<std::vector<int64_t>> shapes = {
+        {102400000},
+        {8192, 8192},
+        {2048, 1024},
+        {512, 512, 256},
+        {128, 128, 64, 16},
+    };
+
+    for (const auto &shape : shapes) {
+        RunAddTest(shape, AddMode::Vectorized);
+    }
+}
+
+TEST(GaloisTests, TestAddVectorizedFill) {
+    // 使用带 Fill 的矢量化实现，验证初始化逻辑的正确性。
+    std::vector<std::vector<int64_t>> shapes = {
+        {102400000},
+        {8192, 8192},
+        {2048, 1024},
+        {512, 512, 256},
+        {128, 128, 64, 16},
+    };
+
+    for (const auto &shape : shapes) {
+        RunAddTest(shape, AddMode::VectorizedFill);
+    }
+}


### PR DESCRIPTION
这个版本只修改了传入的数组中的最后一维。具体逻辑是重建了一个算子，把传入数组的最后一维bitcast成了simd位宽的向量。没有考虑对新建的两个数组的填零操作。 另一个版本VectorizedOptimizer_fill.hpp在做同样的 simd 改写前，会先对新申请的输出张量执行一次 Fill(0)，保证后续写入是在一个已清零的 buffer 上，保持与 BinaryCreator 等需要“先清零再写”的语义。