### PR TITLE
Remove unused code

### DIFF
--- a/tests/operation_count_test.cpp
+++ b/tests/operation_count_test.cpp
@@ -13,7 +13,6 @@ TEST(GaloisTests, TestOperationCount) {
         {ir_mat_type_a, ir_mat_type_b});
 
     auto jit_engine = jit::Engine::Create();
-    auto mat_mul_fun = jit_engine->EmitOperatorSymbol<void *(*)(void *, void *)>(ir_operator);
 
     auto normalize_m = ir_mat_type_a->NormalizeShape()[0];
     auto normalize_k = ir_mat_type_a->NormalizeShape()[1];


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Simplifies the operation count test by removing an unused JIT symbol emission.
> 
> - Deletes the unused `jit_engine->EmitOperatorSymbol<...>(ir_operator)` call in `tests/operation_count_test.cpp`, leaving only the operation counting/assertion logic
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7aba90600bcdf39f05c28e51c532792f938c05a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->